### PR TITLE
Fix for callNative calling callNativeFloat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,7 @@ export const fire = SampNode.fire;
 export const callPublic = SampNode.callPublic;
 export const callPublicFloat = SampNode.callPublicFloat;
 export const logprint = SampNode.logprint;
-export const callNative = SampNode.callNativeFloat;
+export const callNative = SampNode.callNative;
+export const callNativeFloat = SampNode.callNativeFloat;
 
 export {TextDraw,TextDraws,vehicleNames, GetVehicleName, GetVehicleModelId,DynamicObject,getAllVehicle,getPlayers,rgba,SampPlayer,SampNode};


### PR DESCRIPTION
callNative was always using callNativeFloat so natives returning integers were borked.

Credits to https://github.com/plutalov for finding it!